### PR TITLE
Rename attribute "plugin" to "nr.reportingSource"

### DIFF
--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -90,7 +90,7 @@ class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
     payload = {
         :common => {
             :attributes => {
-                :plugin => {
+                'nr.reportingSource' => {
                     :type => 'logstash',
                     :version => LogStash::Outputs::NewRelicVersion::VERSION,
                 }

--- a/lib/logstash/outputs/newrelic_version/version.rb
+++ b/lib/logstash/outputs/newrelic_version/version.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Outputs
     module NewRelicVersion
-      VERSION = "1.1.3"
+      VERSION = "1.1.4"
     end
   end
 end

--- a/spec/outputs/newrelic_spec.rb
+++ b/spec/outputs/newrelic_spec.rb
@@ -32,6 +32,7 @@ describe LogStash::Outputs::NewRelic do
       @newrelic_output.shutdown
     end
   end
+
   context "license key tests" do
     it "sets license key when given in the header" do
       stub_request(:any, base_uri).to_return(status: 200)


### PR DESCRIPTION
I also threw in some tests I had sitting around from a while ago about non-Latin-1 character handling.