### PR TITLE
[LOGGING-3172] Fix bug in BigDecimal JSON serialization

### DIFF
--- a/lib/logstash/outputs/config/bigdecimal_patch.rb
+++ b/lib/logstash/outputs/config/bigdecimal_patch.rb
@@ -1,0 +1,24 @@
+require 'bigdecimal'
+
+class BigDecimal
+    # Floating-point numbers that go through the 'json' Logstash filter get automatically converted into BigDecimals.
+    # Example of such a filter:
+    #
+    # filter {
+    #   json {
+    #     source => "message"
+    #   }
+    # }
+    #
+    # The problem is that { "value" => BigDecimal('0.12345') } gets serialized into { "value": "0.12345e0"}. We do
+    # want to keep floating point numbers serialized as floating point numbers, even at the expense of loosing a little
+    # bit of precision during the conversion. So, in the above example, the correct serialization would be:
+    # { "value": 0.12345e0}
+    def to_json(options = nil) #:nodoc:
+      if finite?
+        self.to_f.to_s
+      else
+        'null'
+      end
+    end
+  end

--- a/lib/logstash/outputs/config/bigdecimal_patch.rb
+++ b/lib/logstash/outputs/config/bigdecimal_patch.rb
@@ -13,7 +13,7 @@ class BigDecimal
     # The problem is that { "value" => BigDecimal('0.12345') } gets serialized into { "value": "0.12345e0"}. We do
     # want to keep floating point numbers serialized as floating point numbers, even at the expense of loosing a little
     # bit of precision during the conversion. So, in the above example, the correct serialization would be:
-    # { "value": 0.12345e0}
+    # { "value": 0.12345}
     def to_json(options = nil) #:nodoc:
       if finite?
         self.to_f.to_s

--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -6,6 +6,7 @@ require 'uri'
 require 'zlib'
 require 'json'
 require 'java'
+require_relative './config/bigdecimal_patch'
 
 class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
   java_import java.util.concurrent.Executors;

--- a/lib/logstash/outputs/newrelic_version/version.rb
+++ b/lib/logstash/outputs/newrelic_version/version.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Outputs
     module NewRelicVersion
-      VERSION = "1.1.3"
+      VERSION = "1.1.4"
     end
   end
 end


### PR DESCRIPTION
# Background

Floating-point numbers that go through the `json` Logstash filter get automatically converted into BigDecimals.
Example of such a filter:

```
filter {
    json {
        source => "message"
    }
}
```

The problem is that `{ "value" => BigDecimal('0.12345') }` gets serialized into `{ "value": "0.12345e0"}`. We do want to keep floating point numbers serialized as floating point numbers, even at the expense of loosing a little bit of precision during the conversion. So, in the above example, the correct serialization would be: `{ "value": 0.12345}`

# Tests
3 unit tests have been included to test the new feature.