### PR TITLE
feat: log message error only when max attempt has being reached

### DIFF
--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -144,16 +144,24 @@ class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
     rescue => e
       # Stuff that should never happen
       # For all other errors print out full issues
-      @logger.error(
-        "An unknown error occurred sending a bulk request to NewRelic.",
-        :error_message => e.message,
-        :error_class => e.class.name,
-        :backtrace => e.backtrace
-      )
       if (should_retry(retries))
+        @logger.warn(
+          "An unknown error occurred sending a bulk request to NewRelic. Retiring...",
+          :retries => " attempt #{retries} of #{@max_retries}",
+          :error_message => e.message,
+          :error_class => e.class.name,
+          :backtrace => e.backtrace
+        )
         retries += 1
         sleep(1)
         retry
+      else
+        @logger.error(
+          "An unknown error occurred sending a bulk request to NewRelic. Max of attempt reached, dropping logs.",
+          :error_message => e.message,
+          :error_class => e.class.name,
+          :backtrace => e.backtrace
+        )
       end
     end
   end

--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -145,19 +145,19 @@ class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
       # Stuff that should never happen
       # For all other errors print out full issues
       if (should_retry(retries))
+        retries += 1
         @logger.warn(
-          "An unknown error occurred sending a bulk request to NewRelic. Retiring...",
-          :retries => " attempt #{retries} of #{@max_retries}",
+          "An unknown error occurred sending a bulk request to NewRelic. Retrying...",
+          :retries => "attempt #{retries} of #{@max_retries}",
           :error_message => e.message,
           :error_class => e.class.name,
           :backtrace => e.backtrace
         )
-        retries += 1
         sleep(1)
         retry
       else
         @logger.error(
-          "An unknown error occurred sending a bulk request to NewRelic. Max of attempt reached, dropping logs.",
+          "An unknown error occurred sending a bulk request to NewRelic. Maximum of attempts reached, dropping logs.",
           :error_message => e.message,
           :error_class => e.class.name,
           :backtrace => e.backtrace

--- a/lib/logstash/outputs/newrelic_version/version.rb
+++ b/lib/logstash/outputs/newrelic_version/version.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Outputs
     module NewRelicVersion
-      VERSION = "1.2.1"
+      VERSION = "1.2.2"
     end
   end
 end


### PR DESCRIPTION
In this PR You would find an optimization on logs when plugin fail to submit a request to NR.

Solves #32 