### PR TITLE
Update action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,8 +21,7 @@ jobs:
         run: jruby -S bundle exec rspec --format RspecJunitFormatter  --out test-results.xml
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.5
+        uses: EnricoMi/publish-unit-test-result-action@v1.19
         if: always()
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           files: test-results.xml


### PR DESCRIPTION
This PR increases the version of publish-unit-test-result-action to the latest 1.19. This way the GITHUB token is not longer required