### PR TITLE
Only retry on fixed set of http status codes and add exponential backoff

### DIFF
--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -13,7 +13,7 @@ require_relative './exception/error'
 class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
   java_import java.util.concurrent.Executors;
 
-  NON_RETRYABLE_CODES = Set[401, 403]
+  RETRIABLE_CODES = Set[408, 429, 500, 502, 503, 504, 599]
 
   MAX_PAYLOAD_SIZE_BYTES = 1_000_000
 
@@ -197,6 +197,6 @@ class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
 
   def is_retryable_code(response_error)
     error_code = response_error.response_code
-    !NON_RETRYABLE_CODES.include?(error_code)
+    RETRIABLE_CODES.include?(error_code)
   end
 end # class LogStash::Outputs::NewRelic

--- a/lib/logstash/outputs/newrelic_version/version.rb
+++ b/lib/logstash/outputs/newrelic_version/version.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Outputs
     module NewRelicVersion
-      VERSION = "1.4.0"
+      VERSION = "1.5.0"
     end
   end
 end


### PR DESCRIPTION
Makes the plugin retry only on the following HTTP status codes: 408, 429, 500, 502, 503, 504 and 599. It also adds a simple exponential backoff mechanism that will wait twice the time each time it retries to send a failed (but retriable) request.

The PR introduces new unit tests to verify each retriable status code.