### PR TITLE
Fix regression resulting in OutOfMemoryError

### DIFF
--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -176,6 +176,9 @@ class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
       @header.each { |k, v| request[k] = v }
       request.body = payload
       handle_response(http.request(request))
+      if (retries > 0)
+        @logger.warn("Successfully sent logs at retry #{retries}")
+      end
     rescue Error::BadResponseCodeError => e
       @logger.error(e.message)
       if (should_retry(retries) && is_retryable_code(e))

--- a/lib/logstash/outputs/newrelic_version/version.rb
+++ b/lib/logstash/outputs/newrelic_version/version.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Outputs
     module NewRelicVersion
-      VERSION = "1.5.0"
+      VERSION = "1.5.1"
     end
   end
 end


### PR DESCRIPTION
In [this PR](https://github.com/newrelic/logstash-output-plugin/pull/37) we removed a Semaphore, incorrectly believing that it was useless. Nevertheless, we were wrong: without the semaphore, Logstash keeps reading inflight requests in memory in an unbounded manner, resulting in an OutOfMemory error and subsequent Logstash crash. This PR fixes this.