### PR TITLE
Use the port from the endpoint url

### DIFF
--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -163,10 +163,10 @@ class LogStash::Outputs::NewRelic < LogStash::Outputs::Base
     retry_duration = 1
 
     begin
-      http = Net::HTTP.new(@end_point.host, 443)
+      http = Net::HTTP.new(@end_point.host, @end_point.port || 443)
       request = Net::HTTP::Post.new(@end_point.request_uri)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      http.use_ssl = (@end_point.scheme == 'https')
+      http.verify_mode = @end_point.scheme == 'https' ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
       if !@custom_ca_cert.nil?
         store = OpenSSL::X509::Store.new
         ca_cert = OpenSSL::X509::Certificate.new(File.read(@custom_ca_cert))

--- a/lib/logstash/outputs/newrelic_version/version.rb
+++ b/lib/logstash/outputs/newrelic_version/version.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Outputs
     module NewRelicVersion
-      VERSION = "1.5.1"
+      VERSION = "1.5.2"
     end
   end
 end


### PR DESCRIPTION
When creating integration tests, I want the newrelic output to send to a local mocked newrelic endpoint that doesn't use https. As so, I just set the newrelic_endpoint to http://restserver:5000/log/v1.

But this logstash plugin hardcodes port 443. This patch uses the port in the url if present and defaults to 443 still.
