### PR TITLE
Add documentation on how to do development using docker containers

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,6 +17,8 @@ we keep using jruby 9.2.13.0 in order to be backwards-compatible with older Logs
 
 # Developing
 
+## Using host machine environment
+
 * Ensure you have `logstash` installed locally (required for unit testing): `brew install logstash`
 * Ensure your `logstash` path matches the one in `Gemfile` 
 * Install dependencies: `jruby -S bundle install`
@@ -24,6 +26,24 @@ we keep using jruby 9.2.13.0 in order to be backwards-compatible with older Logs
 * Bump version: edit version file `version.rb`
 * Run tests: `jruby -S bundle exec rspec`
 * Build the gem: `jruby -S gem build logstash-output-newrelic.gemspec`
+
+## Using docker environment
+
+* First build the container and run it
+```bash
+docker build -t logstash:devel -f Dockerfile.devel .
+docker run -ti --rm -v $(pwd):/usr/share/logstash/logstash-output-plugin:z logstash:devel
+```
+
+* Now inside the container do
+```bash
+cd logstash-output-plugin
+/usr/share/logstash/vendor/bundle/jruby/*/gems/bundler-*/exe/bundle install    # Install dependencies
+/usr/share/logstash/vendor/bundle/jruby/*/gems/bundler-*/exe/bundle exec rspec # Run tests
+```
+
+You can now edit the files outside (in your machine) and execute the tests inside
+the container.
 
 # Testing it with a local Logstash install
 

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -1,0 +1,6 @@
+FROM docker.elastic.co/logstash/logstash-oss:7.17.8
+RUN ln -s ruby  /usr/share/logstash/bin/jruby
+# Run the devel container as root as it's easier to install additional packages
+# like vim or emacs if you want to edit the files inside the container
+USER root
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This patch adds support for running the development environment using docker. It maps the local directory inside docker so that you can still edit the file in your host machine and run the tests inside the docker container and thus not messing with local libraries.