### PR TITLE
Added resolve-replace library to fix open timeouts with http client

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,4 +50,27 @@ jobs:
 
       - name: Logstash E2E testing
         run: ./test.sh ${{ matrix.logstash_version }}
+  
+  test-cd:
+    name: Continuous Delivery pipeline to push pre-release gem to rubygems.org
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup JRuby, bundler and install dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: jruby-9.2.13.0
+      - run: bundle install
+
+      - name: Build gem
+        run: jruby -S gem build logstash-output-newrelic.gemspec
+
+      - name: Publish logstash-output-newrelic to rubygems.org
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+        run: |
+          jruby -S gem push logstash-output-newrelic-1.5.3.pre.beta.gem
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,27 +50,4 @@ jobs:
 
       - name: Logstash E2E testing
         run: ./test.sh ${{ matrix.logstash_version }}
-  
-  test-cd:
-    name: Continuous Delivery pipeline to push pre-release gem to rubygems.org
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup JRuby, bundler and install dependencies
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: jruby-9.2.13.0
-      - run: bundle install
-
-      - name: Build gem
-        run: jruby -S gem build logstash-output-newrelic.gemspec
-
-      - name: Publish logstash-output-newrelic to rubygems.org
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
-        run: |
-          jruby -S gem push logstash-output-newrelic-1.5.3.pre.beta.gem
 

--- a/lib/logstash/outputs/newrelic.rb
+++ b/lib/logstash/outputs/newrelic.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/outputs/newrelic_version/version"
+require 'resolv-replace'
 require 'net/http'
 require 'uri'
 require 'zlib'

--- a/lib/logstash/outputs/newrelic_version/version.rb
+++ b/lib/logstash/outputs/newrelic_version/version.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Outputs
     module NewRelicVersion
-      VERSION = "1.5.2"
+      VERSION = "1.5.3-beta"
     end
   end
 end

--- a/test.sh
+++ b/test.sh
@@ -14,14 +14,14 @@ clean_up () {
     if [[ $ARG -ne 0 ]]; then
       echo "Test failed, showing docker logs"
       echo "- Mockserver"
-      docker-compose -f ./test/docker-compose.yml logs mockserver
+      docker compose -f ./test/docker-compose.yml logs mockserver
       echo "- Logstash ${LOGSTASH_VERSION}"
-      docker-compose -f ./test/docker-compose.yml logs logstash
+      docker compose -f ./test/docker-compose.yml logs logstash
     fi
 
     echo "Cleaning up"
     rm -r ./test/testdata || true
-    docker-compose -f ./test/docker-compose.yml down
+    docker compose -f ./test/docker-compose.yml down
 
     exit $ARG
 }
@@ -53,7 +53,7 @@ function run_test {
   touch ./test/testdata/logstashtest.log
 
   echo "Starting docker compose"
-  docker-compose -f ./test/docker-compose.yml up -d
+  docker compose -f ./test/docker-compose.yml up -d
 
   # Waiting mockserver to be ready
   max_retry=20


### PR DESCRIPTION
We don't plan to release this version yet. One of our customers are facing an issue similar to this one: https://stackoverflow.com/questions/42036133/ruby-netopentimeout-execution-expired

This PR attempts to fix that by using the `resolve-replace` library , which replaces Socket DNS with Resolv in the net/http library.